### PR TITLE
chore: Cleanup pre-commit and pyproject configurations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,34 +1,9 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
     rev: v0.12.5
     hooks:
-      # Run the linter.
       - id: ruff-check
-      # Run the formatter.
       - id: ruff-format
-
-  # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: v1.10.0
-  #   hooks:
-  #     - id: mypy
-  #       language: system
-  #       exclude: ^tests/
-
-  # - repo: local
-  #   hooks:
-  #     - id: pylint
-  #       name: pylint
-  #       entry: pylint
-  #       language: system
-  #       types: [python]
-  #       exclude: ^tests/
-  #       args:
-  #         [
-  #           "--output-format=colorized",
-  #           # "--fail-under=8.0", # Set the minimum score for passing
-  #           # "--fail-on=E,W",  # Only fail on errors (E) and warnings (W)
-  #         ]
 
   - repo: https://github.com/RobertCraigie/pyright-python
     rev: v1.1.403

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,20 +49,3 @@ ignore = [
 venvPath = "."
 venv = ".venv"
 typeCheckingMode = "standard"
-
-# [tool.mypy]
-# python_version = "3.12"
-# ignore_missing_imports = false
-#
-# [[tool.mypy.overrides]]
-# module = ["actual", "actual.queries"]
-# ignore_missing_imports = true
-#
-# [tool.pylint.'MAIN']
-# fail-under = 8.0
-# disable = [
-#     "C3001", # allow lambda expression
-#     "C0114", # missing-module-docstring
-#     "C0115", # missing-class-docstring
-#     "C0116", # missing-function-docstring
-# ]


### PR DESCRIPTION
This pull request focuses on simplifying and cleaning up configuration files by removing unused or commented-out sections. The changes streamline the setup and make the configuration files more concise and easier to maintain.

### Configuration cleanup:

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L3-L32): Removed commented-out sections for unused tools like `mypy` and `pylint`, along with their associated configurations and arguments. This reduces clutter and ensures the file only includes actively used tools.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L52-L68): Deleted commented-out configurations for `mypy` and `pylint`, including settings for Python version, ignored imports, and disabled rules. This further simplifies the file and eliminates unnecessary noise.