### PR TITLE
fix: set explicit httpx timeout for Banco de Chile session 

### DIFF
--- a/ahorratron/sync_api/institutions/banco_de_chile/banco_de_chile.py
+++ b/ahorratron/sync_api/institutions/banco_de_chile/banco_de_chile.py
@@ -106,7 +106,8 @@ class APIClient:
                     "DNT": "1",
                     "Connection": "keep-alive",
                     "Cookie": cookie,
-                }
+                },
+                timeout=httpx.Timeout(timeout=self.TIMEOUT_SECONDS),
             )
             self._session = s
         return self._session

--- a/ahorratron/sync_api/service.py
+++ b/ahorratron/sync_api/service.py
@@ -54,7 +54,7 @@ class Service:
                 logger.exception(
                     "Failed to get accounts for %s", user_data.connector_id
                 )
-                continue
+                raise
             for account in response.results:
                 account.id = self._prefix_id(user_data.connector_id, account.id)
             all_accounts.extend(response.results)


### PR DESCRIPTION
Requests to getCartola and other BdC endpoints could exceed httpx's default 5s timeout, causing intermittent ReadTimeout errors. Service also silently swallowed per-institution account fetch failures, masking sync problems.